### PR TITLE
Allow usage in Unity Editor as a git url based package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name" : "dev.vrlabs.av3manager",
   "displayName" : "Avatars 3.0 Manager",
-  "version" : "master",
+  "version" : "2.0.23",
   "unity" : "2019.4",
   "description" : "A tool for managing playable layers and parameters for Avatars 3.0.",
   "author" : {
@@ -12,7 +12,7 @@
   "vpmDependencies" : {
     "com.vrchat.avatars" : "~3.2.0"
   },
-  "url" : "https://github.com/VRLabs/Avatars-3.0-Manager/releases/download/master/Avatars_3.0_Manager_master.zip",
+  "url" : "https://github.com/VRLabs/Avatars-3.0-Manager/releases/download/master/Avatars_3.0_Manager_2.0.23.zip",
   "legacyFolders" : {
     "Assets\\VRLabs\\Avatars 3.0 Manager" : "513a67139704dd249855ebe5f760cba5"
   }


### PR DESCRIPTION
This allows one to install the manager as a package instead of being forced to import the updated copy every time a new update to the manager is made.

Fixes #17.