### PR TITLE
Update minimum version

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url" : "https://github.vrlabs.dev"
   },
   "vpmDependencies" : {
-    "com.vrchat.avatars" : "~3.2.0"
+    "com.vrchat.avatars" : ">=3.2.0, < 3.4.0"
   },
   "url" : "https://github.com/VRLabs/Avatars-3.0-Manager/releases/download/master/Avatars_3.0_Manager_master.zip",
   "legacyFolders" : {


### PR DESCRIPTION
According to https://github.com/adamreeve/semver.net#ranges, what we had (~3.2.0) was equal to (>=3.2.0 < 3.3.0). I have taken this and bumped the minor version since they shouldn't release breaking changes until 3.4.0