### PR TITLE
Fix clipswapitem error

### DIFF
--- a/Editor/AV3ManagerFunctions.cs
+++ b/Editor/AV3ManagerFunctions.cs
@@ -1,5 +1,4 @@
-﻿#if VRC_SDK_VRCSDK3
-
+﻿
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -954,4 +953,3 @@ namespace VRLabs.AV3Manager
         public bool HasMotion { get; set; }
     }
 }
-#endif

--- a/Editor/AnimatorCloner.cs
+++ b/Editor/AnimatorCloner.cs
@@ -1,4 +1,3 @@
-#if VRC_SDK_VRCSDK3
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -567,5 +566,3 @@ namespace VRLabs.AV3Manager
         }
     }
 }
-
-#endif


### PR DESCRIPTION
ClipSwapItem was caused by the define not being there, causing compile faillures, meaning the define isnt set, etc
