### PR TITLE
Fix/stop breaking changes

### DIFF
--- a/Editor/Elements/AnimatorMergerElement.cs
+++ b/Editor/Elements/AnimatorMergerElement.cs
@@ -88,7 +88,7 @@ namespace VRLabs.AV3Manager
                     var suffixField = new TextField(p.Name).ChildOf(itemContainer);
                     suffixField.tooltip = p.Name;
                     
-                    if (allParameters.Any(x => x.nameHash == param.nameHash && x.type != param.type))
+                    if (layerParameters.Any(x => x.nameHash == param.nameHash && x.type != param.type))
                     {
                         allowMerge = false;
                         new Label("Target controller contains this parameter with a different type than the base controller. These controllers cannot be merged.")

--- a/Editor/Elements/AnimatorMergerElement.cs
+++ b/Editor/Elements/AnimatorMergerElement.cs
@@ -62,6 +62,17 @@ namespace VRLabs.AV3Manager
                 parametersListContainer.Clear();
                 _parametersToMerge.Clear();
 
+
+                if (newController == layer.Controller)
+                {
+                    new Label("Cannot merge controller onto itself.")
+                        .WithClass("red-text")
+                        .ChildOf(parametersListContainer);
+                    mergeOnCurrent.SetEnabled(false);
+                    mergeOnNew.SetEnabled(false);
+                    return;
+                }
+                
                 if (newController == null) return;
 
                 foreach (var param in newController.parameters)

--- a/Editor/Elements/AnimatorMergerElement.cs
+++ b/Editor/Elements/AnimatorMergerElement.cs
@@ -88,9 +88,9 @@ namespace VRLabs.AV3Manager
                     var suffixField = new TextField(p.Name).ChildOf(itemContainer);
                     suffixField.tooltip = p.Name;
                     
-                    if (allParameters.Any(x => x.nameHash == param.nameHash && x.type != param.type && AV3Manager.VrcParameters.Any(x => x == param.name)))
+                    if (allParameters.Any(x => x.nameHash == param.nameHash && x.type != param.type))
                     {
-                        new Label("Target controller contains a built-in parameter with a different type than the base controller. These controllers cannot be merged.")
+                        new Label("Target controller contains a parameter with a different type than the base controller. These controllers cannot be merged.")
                             .WithClass("red-text")
                             .ChildOf(parametersListContainer);
                         allowMerge = false;

--- a/Editor/Elements/AnimatorMergerElement.cs
+++ b/Editor/Elements/AnimatorMergerElement.cs
@@ -90,12 +90,12 @@ namespace VRLabs.AV3Manager
                     
                     if (allParameters.Any(x => x.nameHash == param.nameHash && x.type != param.type))
                     {
-                        new Label("Target controller contains a parameter with a different type than the base controller. These controllers cannot be merged.")
-                            .WithClass("red-text")
-                            .ChildOf(parametersListContainer);
                         allowMerge = false;
+                        new Label("Target controller contains this parameter with a different type than the base controller. These controllers cannot be merged.")
+                            .WithClass("red-text")
+                            .ChildOf(itemContainer);
                     } 
-                    else if (AV3Manager.VrcParameters.Any(x => x == param.name))
+                    if (AV3Manager.VrcParameters.Any(x => x == param.name))
                     {
                         new Label("Parameter is a default one, by default it will be added to the parameters, but not listed in the synced parameters, you should not add any affix unless you know what you're doing")
                             .WithClass("warning-label")
@@ -130,6 +130,13 @@ namespace VRLabs.AV3Manager
                     });
 
                     _parametersToMerge.Add(p);
+                }
+
+                if (!allowMerge)
+                {
+                    new Label("Target controller contains a parameter with a different type than the base controller. These controllers cannot be merged.")
+                        .WithClass("red-text")
+                        .ChildOf(parametersListContainer);
                 }
                 
                 mergeOnCurrent.SetEnabled(allowMerge);

--- a/Editor/Tabs/LayersTab.cs
+++ b/Editor/Tabs/LayersTab.cs
@@ -382,7 +382,6 @@ namespace VRLabs.AV3Manager
                              x.type == AnimatorControllerParameterType.Float ||
                              x.type == AnimatorControllerParameterType.Bool))
                 {
-                    if (AV3Manager.VrcParameters.Count(x => x.Equals(parameter.name)) > 0) continue;
                     bool isExpression = _expressionParameters != null && _expressionParameters.FindParameter(parameter.name) != null;
                     bool isSynced = isExpression
                         ? _expressionParameters.FindParameter(parameter.name).networkSynced


### PR DESCRIPTION
Both stops merging when a parameter is being used with a different type from the base controller, and stops merging a controller onto itself.