### PR TITLE
Enable custom expressions

### DIFF
--- a/Editor/AV3ManagerFunctions.cs
+++ b/Editor/AV3ManagerFunctions.cs
@@ -161,6 +161,7 @@ namespace VRLabs.AV3Manager
             AssetDatabase.SaveAssets();
             AssetDatabase.Refresh();
             descriptor.expressionParameters = parameters;
+            descriptor.customExpressions = true;
         }
         
         /// <summary>


### PR DESCRIPTION
Fixes " Avatar with no custom menu or param > Merges FX with AV3 > Avatar is given a null menu (despite it not being visual) > avatar cannot upload until "reset to default" is clicked"