### PR TITLE
Support for SDK 3.9.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "siteUrl": "https://github.com/VRLabs/Avatars-3.0-Manager",
   "vpmDependencies": {
-    "com.vrchat.avatars": "3.2 - 3.8"
+    "com.vrchat.avatars": "3.2 - 3.9"
   },
   "legacyFolders": {
     "Assets\\VRLabs\\Avatars 3.0 Manager": "513a67139704dd249855ebe5f760cba5"


### PR DESCRIPTION
Bumps maximum supported version to 3.9.0 since it's now public.

Noticed no issues with it on AV3Manager v2.1.0.